### PR TITLE
Fixes for newer versions of numpy

### DIFF
--- a/scripts/f2py-f90wrap
+++ b/scripts/f2py-f90wrap
@@ -110,7 +110,7 @@ void f90wrap_abort_int_handler(int signum)
 
 numpy.f2py.rules.module_rules['modulebody'] = numpy.f2py.rules.module_rules['modulebody'].replace("#includes0#\n", includes_inject)
 
-numpy.f2py.rules.routine_rules['body'] = numpy.f2py.rules.routine_rules['body'].replace('\tvolatile int f2py_success = 1;\n', """\tvolatile int f2py_success = 1;
+numpy.f2py.rules.routine_rules['body'] = numpy.f2py.rules.routine_rules['body'].replace('volatile int f2py_success = 1;\n', """volatile int f2py_success = 1;
 \tint setjmpvalue; /* James Kermode - for setjmp */
 """)
 


### PR DESCRIPTION
Hi Caoxiang,

I had to slightly adjust the `f2py-f90wrap` script in order to use it with `numpy=1.20.1` and the `f2py` contained therein.
It seems that numpy changed the indentation character they use in the auto-generated code from `\t` to spaces and thus, the pattern in `f2py-f90wrap` does not match anymore. However, this can be fixed by simply excluding the `\t` from the pattern (see diff).

Best,
 Jonathan